### PR TITLE
Add nested matcher example

### DIFF
--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	. "github.com/arran4/gorillamuxlogic"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+func RequiredScopes(scope string) mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool { return true }
+}
+
+func CommentAuthor() mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool { return true }
+}
+
+func articleEditPage(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	mux.NewRouter().
+		HandleFunc("/articles/{id}/edit", articleEditPage).
+		MatcherFunc(
+			Or(
+				And(RequiredScopes("administrator"), CommentAuthor()),
+				And(RequiredScopes("editor"), Not(CommentAuthor())),
+			),
+		).
+		Methods("POST")
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	. "github.com/arran4/gorillamuxlogic"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+func UserMiddleware(next http.Handler) http.Handler { return next }
+
+func RequiredScopes(scope string) mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool { return true }
+}
+
+func CommentAuthor() mux.MatcherFunc {
+	return func(r *http.Request, m *mux.RouteMatch) bool { return true }
+}
+
+func blogsCommentEditPage(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	mux.NewRouter().
+		Use(UserMiddleware).
+		HandleFunc("/blog/{blog}/comment/{comment}/edit", blogsCommentEditPage).
+		MatcherFunc(Or(RequiredScopes("administrator"), CommentAuthor())).
+		Methods("POST")
+}

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ func main() {
 }
 ```
 
+Examples of runnable programs can be found under the `examples/` directory.
+
 Provides functions:
 ```go
 func And(matchers ...mux.MatcherFunc) mux.MatcherFunc
@@ -27,4 +29,18 @@ func Or(matchers ...mux.MatcherFunc) mux.MatcherFunc
 
 func Not(matcher mux.MatcherFunc) mux.MatcherFunc
 
+```
+
+Nested logic example:
+
+```go
+mux.NewRouter().
+        HandleFunc("/articles/{id}/edit", articleEditPage).
+        MatcherFunc(
+                Or(
+                        And(RequiredScopes("administrator"), CommentAuthor()),
+                        And(RequiredScopes("editor"), Not(CommentAuthor())),
+                ),
+        ).
+        Methods("POST")
 ```


### PR DESCRIPTION
## Summary
- extend README with an example showing nested `And` and `Or`
- add runnable example programs under `examples/`

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/github.com/gorilla/mux/@v/v1.8.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c86c190d0832fbb3bbebe1b8f9920