### PR TITLE
Fix example code and clean README

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -19,9 +19,9 @@ func CommentAuthor() mux.MatcherFunc {
 func blogsCommentEditPage(w http.ResponseWriter, r *http.Request) {}
 
 func main() {
-	mux.NewRouter().
-		Use(UserMiddleware).
-		HandleFunc("/blog/{blog}/comment/{comment}/edit", blogsCommentEditPage).
+	r := mux.NewRouter()
+	r.Use(UserMiddleware)
+	r.HandleFunc("/blog/{blog}/comment/{comment}/edit", blogsCommentEditPage).
 		MatcherFunc(Or(RequiredScopes("administrator"), CommentAuthor())).
 		Methods("POST")
 }

--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,11 @@ import (
 )
 
 func main() {
-	mux.NewRouter().
-		Use(UserMiddleware).
-		HandleFunc("/blog/{blog}/comment/{comment}/edit", blogsCommentEditPage).
-		MatcherFunc(Or(RequiredScopes("administrator"), CommentAuthor())).
-		Methods("POST")
+        r := mux.NewRouter()
+        r.Use(UserMiddleware)
+        r.HandleFunc("/blog/{blog}/comment/{comment}/edit", blogsCommentEditPage).
+                MatcherFunc(Or(RequiredScopes("administrator"), CommentAuthor())).
+                Methods("POST")
 }
 ```
 
@@ -31,7 +31,6 @@ func Not(matcher mux.MatcherFunc) mux.MatcherFunc
 
 ```
 
-<<<<<<< codex/add-example-for-nested-and/or-usage
 Nested logic example:
 
 ```go
@@ -45,7 +44,7 @@ mux.NewRouter().
         ).
         Methods("POST")
 ```
-=======
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
@@ -57,6 +56,3 @@ To add this package to your project, run:
 ```
 go get github.com/arran4/gorillamuxlogic
 ```
-
-
->>>>>>> main


### PR DESCRIPTION
## Summary
- fix Basic example to use `Use` correctly
- clean up README merge markers and update middleware example

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865f0b85524832f9e5c09c9920ef2da